### PR TITLE
Add composer.json file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "barrykooij/post-connector-core",
-	"version": "0.0.1",
+	"version": "1.0.1",
 	"dist": {
 		"url": "https://github.com/barrykooij/post-connector-core/archive/master.zip",
 		"type": "zip"


### PR DESCRIPTION
I'd like to include this library in one of my projects, via Composer. Therefore, I need it to have its own `composer.json` file. This enables you to add this repository as a dependency to any project.

Also added `PSR-0` autoloading on the `classes` folder as that should ideally just be autoloaded. It's just classes in there that don't include each other, right? If not, we should make that happen. :smile:
