### PR TITLE
.DS_Store files should be ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
Probably a ton of other files can be ignored, but these little `.DS_Store` files are just annoying.
