### PR TITLE
Filter for stop redirect on save

### DIFF
--- a/classes/meta-boxes/class-meta-box-meta.php
+++ b/classes/meta-boxes/class-meta-box-meta.php
@@ -270,10 +270,15 @@ class SP_Meta_Box_Meta {
 		if ( $sp_parent_rest != '' ) {
 			$redirect_url .= '&sp_parent=' . $sp_parent_rest;
 		}
+		
+		// Allow stopping the redirect to the parent page
+		if(apply_filters('pc_redirect_to_parent_after_save', true)) {
 
-		// Redirecting user
-		wp_redirect( $redirect_url );
-		exit;
+			// Redirecting user
+			wp_redirect( $redirect_url );
+			exit;
+			
+		}
 	}
 
 }


### PR DESCRIPTION
Added filter `pc_redirect_to_parent_after_save` for allowing stopping redirect to parent after a child has been saved.